### PR TITLE
feat: add metrics field in read response

### DIFF
--- a/protos/engine/remote_engine.proto
+++ b/protos/engine/remote_engine.proto
@@ -62,12 +62,13 @@ message ReadResponse {
   common.ResponseHeader header = 1;
   oneof output {
     storage.ArrowPayload arrow = 2;
-    MetricPayload metrics = 3;
+    // This field is used to return metric of child node when query is executed in distributed mode.
+    MetricPayload metric = 3;
   }
 }
 
 message MetricPayload {
-  string metrics = 1;
+  string metric = 1;
 }
 
 message ColumnDesc {

--- a/protos/engine/remote_engine.proto
+++ b/protos/engine/remote_engine.proto
@@ -63,7 +63,7 @@ message ReadResponse {
   oneof output {
     storage.ArrowPayload arrow = 2;
   }
-  optional string metrics = 3;
+  string metrics = 3;
 }
 
 message ColumnDesc {

--- a/protos/engine/remote_engine.proto
+++ b/protos/engine/remote_engine.proto
@@ -63,6 +63,7 @@ message ReadResponse {
   oneof output {
     storage.ArrowPayload arrow = 2;
   }
+  optional string metrics = 3;
 }
 
 message ColumnDesc {

--- a/protos/engine/remote_engine.proto
+++ b/protos/engine/remote_engine.proto
@@ -62,7 +62,8 @@ message ReadResponse {
   common.ResponseHeader header = 1;
   oneof output {
     storage.ArrowPayload arrow = 2;
-    // This field is used to return metric of child node when query is executed in distributed mode.
+    // This field is used to return metric of child node when query is executed
+    // in distributed mode.
     MetricPayload metric = 3;
   }
 }

--- a/protos/engine/remote_engine.proto
+++ b/protos/engine/remote_engine.proto
@@ -62,8 +62,12 @@ message ReadResponse {
   common.ResponseHeader header = 1;
   oneof output {
     storage.ArrowPayload arrow = 2;
+    MetricPayload metrics = 3;
   }
-  string metrics = 3;
+}
+
+message MetricPayload {
+  string metrics = 1;
 }
 
 message ColumnDesc {


### PR DESCRIPTION
In distributed sql analyze, we need to return the metrics of the child node, so we add a metrics field in read response.